### PR TITLE
fix: escape backslashes in renovate.json matchStrings regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -118,7 +118,7 @@
     {
       "customType": "regex",
       "description": "Update ghalint and actionlint versions in ghalint workflow",
-      "managerFilePatterns": ["/^\.github/workflows/ghalint\.yml$/"],
+      "managerFilePatterns": ["/^\\.github/workflows/ghalint\\.yml$/"],
       "matchStrings": ["# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+version=v?(?<currentValue>[^\\s]+)"],
       "versioningTemplate": "semver"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -119,7 +119,7 @@
       "customType": "regex",
       "description": "Update ghalint and actionlint versions in ghalint workflow",
       "managerFilePatterns": ["/^\.github/workflows/ghalint\.yml$/"],
-      "matchStrings": ["# renovate: datasource=(?<datasource>[^\s]+) depName=(?<depName>[^\s]+)\s+version=v?(?<currentValue>[^\s]+)"],
+      "matchStrings": ["# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+version=v?(?<currentValue>[^\\s]+)"],
       "versioningTemplate": "semver"
     }
   ],


### PR DESCRIPTION
## Summary
- `customManagers[].matchStrings` の正規表現パターン内の `\s` を `\\s` に修正

## Background / Motivation
Renovate が `renovate.json` を厳密な JSON としてパースしようとした際に、`\s` が有効な JSON エスケープシーケンスでないため警告が出ていた。JSON では `\\` と書くことで1つのバックスラッシュを表現するため、正規表現中のバックスラッシュはすべてエスケープする必要がある。Renovate が実際に受け取る正規表現の値は変わらない。