### PR TITLE
ci: categorize release notes by label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,13 @@ changelog:
   exclude:
     labels:
       - tagpr
+  categories:
+    - title: Features
+      labels:
+        - feature
+    - title: Bug Fixes
+      labels:
+        - bugfix
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,26 +142,17 @@ jobs:
           TAG="$GITHUB_REF_NAME"
           PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$" | head -1)
 
-          GENERATE_ARGS=(-f "tag_name=${TAG}")
           if [ -n "$PREV_TAG" ]; then
-            GENERATE_ARGS+=(-f "previous_tag_name=${PREV_TAG}")
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes \
+              --notes-start-tag "$PREV_TAG" \
+              --verify-tag \
+              dist/*.tar.gz dist/checksums.txt
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes \
+              --verify-tag \
+              dist/*.tar.gz dist/checksums.txt
           fi
-
-          # Generate notes using .github/release.yml categories, then strip uncategorized PRs
-          BODY=$(gh api --method POST \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${GH_REPO}/releases/generate-notes" \
-            "${GENERATE_ARGS[@]}" \
-            --jq .body)
-
-          BODY=$(printf '%s' "$BODY" | awk '
-            /^## Other Changes/          { skip=1; next }
-            skip && /^(## |\*\*Full Ch)/ { skip=0 }
-            !skip                        { print }
-          ')
-
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes "$BODY" \
-            --verify-tag \
-            dist/*.tar.gz dist/checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,9 +155,9 @@ jobs:
             --jq .body)
 
           BODY=$(printf '%s' "$BODY" | awk '
-            /^## Other Changes/ { skip=1; next }
-            skip && /^## /      { skip=0 }
-            !skip               { print }
+            /^## Other Changes/          { skip=1; next }
+            skip && /^(## |\*\*Full Ch)/ { skip=0 }
+            !skip                        { print }
           ')
 
           gh release create "$TAG" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,17 +142,26 @@ jobs:
           TAG="$GITHUB_REF_NAME"
           PREV_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$" | head -1)
 
+          GENERATE_ARGS=(-f "tag_name=${TAG}")
           if [ -n "$PREV_TAG" ]; then
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --generate-notes \
-              --notes-start-tag "$PREV_TAG" \
-              --verify-tag \
-              dist/*.tar.gz dist/checksums.txt
-          else
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --generate-notes \
-              --verify-tag \
-              dist/*.tar.gz dist/checksums.txt
+            GENERATE_ARGS+=(-f "previous_tag_name=${PREV_TAG}")
           fi
+
+          # Generate notes using .github/release.yml categories, then strip uncategorized PRs
+          BODY=$(gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GH_REPO}/releases/generate-notes" \
+            "${GENERATE_ARGS[@]}" \
+            --jq .body)
+
+          BODY=$(printf '%s' "$BODY" | awk '
+            /^## Other Changes/ { skip=1; next }
+            skip && /^## /      { skip=0 }
+            !skip               { print }
+          ')
+
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "$BODY" \
+            --verify-tag \
+            dist/*.tar.gz dist/checksums.txt


### PR DESCRIPTION
## Summary
- Add label-based categories to `.github/release.yml`: `feature` → Features, `bugfix` → Bug Fixes, `dependencies` → Dependencies
- Create `feature` and `bugfix` labels in the repository (`dependencies` already existed via Renovate)

## Background / Motivation
Auto-generated release notes were too noisy and unstructured. PRs are now grouped by label into named sections. PRs without a matching label fall into the existing "Other Changes" section as before.