### PR TITLE
ci: run integration test after digest verification on tagpr PRs

### DIFF
--- a/.github/workflows/verify-release-image.yml
+++ b/.github/workflows/verify-release-image.yml
@@ -60,7 +60,7 @@ jobs:
           fi
           echo "OK: action.yml digest matches $EXPECTED_TAG"
 
-  test:
+  integration-test:
     needs: verify
     if: startsWith(github.head_ref, 'tagpr-from-')
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-release-image.yml
+++ b/.github/workflows/verify-release-image.yml
@@ -59,3 +59,51 @@ jobs:
             exit 1
           fi
           echo "OK: action.yml digest matches $EXPECTED_TAG"
+
+  test:
+    needs: verify
+    if: startsWith(github.head_ref, 'tagpr-from-')
+    runs-on: ubuntu-latest
+    environment:
+      name: main
+      deployment: false
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-test-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+
+      - name: Run action
+        id: token
+        uses: ./
+        with:
+          app_id: ${{ secrets.BOT_GITHUB_APP_ID }}
+          kms_key_id: ${{ secrets.KMS_KEY_ID }}
+          kms_keyring_id: ${{ secrets.KMS_KEYRING_ID }}
+          kms_location: ${{ vars.KMS_LOCATION }}
+          kms_project_id: ${{ vars.KMS_PROJECT_ID }}
+          owner: yagihash
+          repositories: |
+            ghat
+          permission_contents: read
+          permission_pull_requests: read
+
+      - name: Test token
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh auth status


### PR DESCRIPTION
## Summary
- Add `test` job to `verify-release-image.yml` that runs after the `verify` job succeeds
- Triggers only for `tagpr-from-*` head branches
- Uses concurrency with `cancel-in-progress: true` to cancel runs for older commits
- Runs the action with real GCP/KMS credentials and checks the issued token

## Background / Motivation
`build-release.yml` runs the action to issue a token, but it uses the previous image (one generation old). By running the integration test after `verify` confirms the digest is correct, we can validate the newly built image end-to-end before merging the release PR.