### PR TITLE
feat: attest release artifacts and document macOS installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,3 +156,13 @@ jobs:
               --verify-tag \
               dist/*.tar.gz dist/checksums.txt
           fi
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/ghat_*_linux_amd64.tar.gz
+            dist/ghat_*_linux_arm64.tar.gz
+            dist/ghat_*_darwin_amd64.tar.gz
+            dist/ghat_*_darwin_arm64.tar.gz
+            dist/checksums.txt

--- a/README.md
+++ b/README.md
@@ -130,7 +130,22 @@ CLOUDSDK_PYTHON_SITEPACKAGES=1 gcloud kms keys versions import \
 ```
 
 ## For other use-cases
-You can use this for other general use-cases. I will include executables in releases later.
+You can also use this as a standalone CLI tool. Binaries for Linux and macOS are available in [GitHub Releases](https://github.com/yagihash/ghat/releases).
+
+### Installing from GitHub Releases
+
+Download the binary for your platform and verify build provenance with [GitHub Attestation](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds):
+
+```bash
+gh release download --repo yagihash/ghat --pattern "ghat_*_darwin_arm64.tar.gz"
+gh attestation verify ghat_*_darwin_arm64.tar.gz --repo yagihash/ghat
+tar -xzf ghat_*_darwin_arm64.tar.gz
+
+# macOS only: remove quarantine attribute added by the OS when downloading files
+xattr -d com.apple.quarantine ./ghat
+```
+
+### Installing with go install
 
 ```bash
 go install github.com/yagihash/ghat/v2/cmd/ghat@latest


### PR DESCRIPTION
## Summary

- Add `actions/attest-build-provenance@v4.1.0` to `release.yml` to generate build provenance attestations for all release tarballs
- Update README to document how to install from GitHub Releases, including attestation verification and macOS quarantine removal

## Background / Motivation

Release binaries for macOS were blocked by Gatekeeper because they lacked Apple code signing. Rather than enrolling in Apple Developer Program, we opted for a lighter approach:

- **Build provenance via GitHub Attestation** lets users cryptographically verify that a tarball was produced by this repository's release workflow
- **`xattr -d com.apple.quarantine`** removes the macOS quarantine attribute that Gatekeeper uses to block unsigned downloads

After this change, users can verify and run the binary with:

```bash
gh release download --repo yagihash/ghat --pattern "ghat_*_darwin_arm64.tar.gz"
gh attestation verify ghat_*_darwin_arm64.tar.gz --repo yagihash/ghat
tar -xzf ghat_*_darwin_arm64.tar.gz
xattr -d com.apple.quarantine ./ghat
```