### PR TITLE
feat: show token scope as collapsible log groups in GitHub Actions

### DIFF
--- a/cmd/ghat/main.go
+++ b/cmd/ghat/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/yagihash/ghat/v2/internal/actions"
@@ -69,7 +68,10 @@ func realMain() int {
 	if len(args.Repositories) == 0 {
 		actions.LogNotice("Token will be scoped to all repositories accessible by the GitHub App installation")
 	} else {
-		actions.LogNotice(fmt.Sprintf("Token will be scoped to %d repositories: %s", len(args.Repositories), strings.Join(args.Repositories, ", ")))
+		actions.LogGroup(
+			fmt.Sprintf("Token scope: %d repositories", len(args.Repositories)),
+			args.Repositories...,
+		)
 	}
 
 	if len(args.Permissions) == 0 {
@@ -79,7 +81,10 @@ func realMain() int {
 		for k, v := range args.Permissions {
 			perms = append(perms, k+":"+v)
 		}
-		actions.LogNotice(fmt.Sprintf("Token will be granted %d permissions: %s", len(args.Permissions), strings.Join(perms, ", ")))
+		actions.LogGroup(
+			fmt.Sprintf("Token scope: %d permissions", len(args.Permissions)),
+			perms...,
+		)
 	}
 
 	accessToken, err := c.GetInstallationAccessToken(installation.ID, args.Permissions, args.Repositories)

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -64,7 +64,7 @@ func GetState(key string) (string, error) {
 }
 
 func LogGroup(title string, messages ...string) {
-	fmt.Print("::group::" + title)
+	fmt.Println("::group::" + title)
 	for _, v := range messages {
 		fmt.Println(v)
 	}

--- a/internal/actions/actions_test.go
+++ b/internal/actions/actions_test.go
@@ -271,14 +271,9 @@ func TestAddMask(t *testing.T) {
 
 func TestLogGroup(t *testing.T) {
 	out := captureStdout(t, func() { LogGroup("my group", "line1", "line2") })
-	if !strings.HasPrefix(out, "::group::my group") {
-		t.Errorf("output should start with ::group::my group, got %q", out)
-	}
-	if !strings.Contains(out, "line1") || !strings.Contains(out, "line2") {
-		t.Errorf("output should contain messages, got %q", out)
-	}
-	if !strings.Contains(out, "::endgroup::") {
-		t.Errorf("output should contain ::endgroup::, got %q", out)
+	want := "::group::my group\nline1\nline2\n::endgroup::\n"
+	if out != want {
+		t.Errorf("output = %q, want %q", out, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Use `::group::` / `::endgroup::` workflow commands to wrap repository and permission scope output in collapsible sections
- Fix a bug in `LogGroup` where `fmt.Print` (no newline) caused the first message to appear on the same line as the group title
- Tighten `TestLogGroup` assertion to exact-match instead of loose `HasPrefix`/`Contains` checks
- Remove unused `"strings"` import from `cmd/ghat/main.go`

## Background / Motivation

The previous implementation joined all repositories and permissions into a single `::notice::` line separated by `", "`. With many repos or fine-grained permissions this becomes a hard-to-read one-liner. GitHub Actions supports collapsible log groups via `::group::` commands — using them here makes the scope summary much easier to scan while keeping the UI uncluttered by default.