### PR TITLE
fix: ensure attestation succeeds before creating GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
@@ -133,6 +134,16 @@ jobs:
           tar -czf dist/licenses.tar.gz -C dist licenses
           sha256sum dist/*.tar.gz > dist/checksums.txt
 
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/ghat_*_linux_amd64.tar.gz
+            dist/ghat_*_linux_arm64.tar.gz
+            dist/ghat_*_darwin_amd64.tar.gz
+            dist/ghat_*_darwin_arm64.tar.gz
+            dist/checksums.txt
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -156,13 +167,3 @@ jobs:
               --verify-tag \
               dist/*.tar.gz dist/checksums.txt
           fi
-
-      - name: Attest release artifacts
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
-        with:
-          subject-path: |
-            dist/ghat_*_linux_amd64.tar.gz
-            dist/ghat_*_linux_arm64.tar.gz
-            dist/ghat_*_darwin_amd64.tar.gz
-            dist/ghat_*_darwin_arm64.tar.gz
-            dist/checksums.txt

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Download the binary for your platform and verify build provenance with [GitHub A
 
 ```bash
 gh release download --repo yagihash/ghat --pattern "ghat_*_darwin_arm64.tar.gz"
-gh attestation verify ghat_*_darwin_arm64.tar.gz --repo yagihash/ghat
+gh attestation verify ghat_*_darwin_arm64.tar.gz --repo yagihash/ghat --signer-workflow yagihash/ghat/.github/workflows/release.yml
 tar -xzf ghat_*_darwin_arm64.tar.gz
 
 # macOS only: remove quarantine attribute added by the OS when downloading files


### PR DESCRIPTION
## Summary

- Add missing `attestations: write` permission to `release.yml` required by `actions/attest-build-provenance`
- Move the Attest step before the Create GitHub Release step so that attestation failure blocks release creation
- Update `gh attestation verify` command in README to include `--signer-workflow` for stricter provenance verification

## Background / Motivation

The `release.yml` workflow was missing the `attestations: write` permission, causing the Attest step to fail with "Resource not accessible by integration". Because the Attest step ran _after_ the Create GitHub Release step, the release was published successfully even though no attestation was stored — making `gh attestation verify` return HTTP 404.

Moving Attest before Create GitHub Release ensures the release is never published without valid provenance. Adding `--signer-workflow` to the README verification command tightens the check to confirm the artifact was signed specifically by `release.yml`, not just any workflow in the repo.