### PR TITLE
fix: remove USER nobody from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,3 @@ RUN upx --best /post
 FROM alpine:3.23.3
 COPY --from=builder /ghat /ghat
 COPY --from=builder /post /post
-USER nobody


### PR DESCRIPTION
## Summary
- Remove `USER nobody` from the final stage of the Dockerfile

## Background / Motivation
`USER nobody` was added in #122, but it causes `permission denied` when the ghat container tries to read the Google Cloud credentials JSON file written by `google-github-actions/auth`. The file is owned by the runner user and is not readable by `nobody`, breaking the "Create GitHub App Token" step in `build-release.yml`.