### PR TITLE
fix: create GitHub App Token after Docker build to avoid stale image

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -33,19 +33,6 @@ jobs:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
 
-      - name: Create GitHub App Token
-        id: token
-        uses: ./
-        with:
-          app_id: ${{ secrets.BOT_GITHUB_APP_ID }}
-          kms_key_id: ${{ secrets.KMS_KEY_ID }}
-          kms_keyring_id: ${{ secrets.KMS_KEYRING_ID }}
-          kms_location: ${{ vars.KMS_LOCATION }}
-          kms_project_id: ${{ vars.KMS_PROJECT_ID }}
-          owner: yagihash
-          repositories: ghat
-          permission_contents: write
-
       - name: Login to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -73,6 +60,19 @@ jobs:
           DIGEST: ${{ steps.docker.outputs.digest }}
         run: |
           sed -i "s|image: \"docker://.*\"|image: \"docker://$DIGEST\"|g" action.yml
+
+      - name: Create GitHub App Token
+        id: token
+        uses: ./
+        with:
+          app_id: ${{ secrets.BOT_GITHUB_APP_ID }}
+          kms_key_id: ${{ secrets.KMS_KEY_ID }}
+          kms_keyring_id: ${{ secrets.KMS_KEYRING_ID }}
+          kms_location: ${{ vars.KMS_LOCATION }}
+          kms_project_id: ${{ vars.KMS_PROJECT_ID }}
+          owner: yagihash
+          repositories: ghat
+          permission_contents: write
 
       - name: Commit and push
         env:


### PR DESCRIPTION
## Summary
- Move the "Create GitHub App Token" step to after "Build and Push Docker Image" and "Update action.yml with image digest"

## Background / Motivation
`uses: ./` resolves the Docker image from `action.yml` at step execution time, not at workflow parse time. By moving the token step after the build steps, `uses: ./` always runs the **freshly built image** rather than the previous generation's image stored in `action.yml`.

This breaks the chicken-and-egg cycle where a broken previous-generation image (e.g., one with `USER nobody` that can't read GCP credentials) would permanently block `build-release.yml` from succeeding and updating `action.yml` with a new working image.