### PR TITLE
fix: fix refs/heads/ typo in writer.rego

### DIFF
--- a/.github/mini-gh-sts/writer.rego
+++ b/.github/mini-gh-sts/writer.rego
@@ -10,9 +10,9 @@ permissions := {
 default allow := false
 
 allow if {
-	input.sub == "repo:yagihash/ghat:refs/head/main"
+	input.sub = "repo:yagihash/ghat:refs/heads/main"
 }
 
 allow if {
-	startswith(input.sub, "repo:yagihash/ghat:refs/head/tagpr-from-")
+	startswith(input.sub, "repo:yagihash/ghat:refs/heads/tagpr-from-")
 }


### PR DESCRIPTION
## Summary
- Fix `refs/head/` → `refs/heads/` to match the actual GitHub Actions OIDC sub claim format

## Background / Motivation
The `tagpr` workflow was failing with `token issuance denied by policy`. The sub claim in the GitHub Actions OIDC token uses `refs/heads/` (plural), but the policy had `refs/head/` (singular), so the allow rule never matched.