### PR TITLE
style: restore == operator in writer.rego

### DIFF
--- a/.github/mini-gh-sts/writer.rego
+++ b/.github/mini-gh-sts/writer.rego
@@ -10,7 +10,7 @@ permissions := {
 default allow := false
 
 allow if {
-	input.sub = "repo:yagihash/ghat:refs/heads/main"
+	input.sub == "repo:yagihash/ghat:refs/heads/main"
 }
 
 allow if {


### PR DESCRIPTION
## Summary
- Restore `==` (equality) operator in place of `=` (unification) for string comparison in writer.rego

## Background / Motivation
The previous PR (#132) accidentally used `=` instead of `==`. Both work in Rego, but `==` is the preferred form for explicit equality checks.