### PR TITLE
feat: migrate tagpr and pinact to use sts-action for token

### DIFF
--- a/.github/mini-gh-sts/writer.rego
+++ b/.github/mini-gh-sts/writer.rego
@@ -10,9 +10,9 @@ permissions := {
 default allow := false
 
 allow if {
-	input.sub == "repo:yagihash/ghat:refs/heads/main"
+	input.sub == "repo:yagihash/ghat:environment:main"
 }
 
 allow if {
-	startswith(input.sub, "repo:yagihash/ghat:refs/heads/tagpr-from-")
+	input.sub == "repo:yagihash/ghat:refs/heads/main"
 }

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -8,14 +8,10 @@ on:
 jobs:
   pinact:
     runs-on: ubuntu-latest
-    environment:
-      name: main
-      deployment: false
     timeout-minutes: 15
     permissions:
       contents: read
       id-token: write
-      attestations: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -9,13 +9,9 @@ on:
 jobs:
   tagpr:
     runs-on: ubuntu-latest
-    environment:
-      name: main
-      deployment: false
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
       id-token: write
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /dist
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Migrate `tagpr.yml` and `pinact.yml` to use `yagihash/sts-action` (mini-gh-sts) for GitHub App token acquisition instead of the GCP KMS-based approach
- Remove `environment: main` from both workflows since GCP Workload Identity Federation is no longer needed
- Reduce permissions in `tagpr.yml`: `contents: read` is sufficient (tagpr uses the app token for write operations)
- Update `writer.rego` to allow `environment:main` sub claim and restrict to main branch refs
- Add `.claude/scheduled_tasks.lock` to `.gitignore`

## Background / Motivation
The GCP KMS-based token flow (`google-github-actions/auth` + `uses: ./`) requires the `environment: main` deployment gate, which adds friction and latency. Using `yagihash/sts-action` with GitHub Actions OIDC directly is simpler and removes the GCP dependency from these workflows.