### PR TITLE
feat: log token hash to Actions execution log for incident investigation

### DIFF
--- a/cmd/ghat/main.go
+++ b/cmd/ghat/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"time"
@@ -94,6 +96,9 @@ func realMain() int {
 	}
 	if isActions {
 		actions.AddMask(accessToken.Token)
+
+		hash := sha256.Sum256([]byte(accessToken.Token))
+		actions.LogNotice("Token hash: " + base64.StdEncoding.EncodeToString(hash[:]))
 
 		if err := actions.SetState("token", accessToken.Token); err != nil {
 			actions.LogError(err.Error())


### PR DESCRIPTION
## Summary
- Add SHA-256 hash output (`Token hash: Base64(sha256(token))`) to the Actions execution log after token issuance
- The token itself remains masked via `AddMask`; only the hash is visible in the log

## Background / Motivation
When a security incident occurs, there is currently no way to correlate a token seen in external logs with the one issued by this action. Logging the Base64-encoded SHA-256 hash of the token allows incident responders to verify whether a specific token was issued without exposing the token itself.

Closes #143