### PR TITLE
fix: use fileMatch in customManagers for validator compatibility

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -118,7 +118,7 @@
     {
       "customType": "regex",
       "description": "Update ghalint and actionlint versions in ghalint workflow",
-      "managerFilePatterns": ["/^\\.github/workflows/ghalint\\.yml$/"],
+      "fileMatch": ["^\\.github/workflows/ghalint\\.yml$"],
       "matchStrings": ["# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+version=v?(?<currentValue>[^\\s]+)"],
       "versioningTemplate": "semver"
     }


### PR DESCRIPTION
## Summary

Fixes #145.

`renovate-config-validator` was rejecting the `customManagers` block with:

```
Custom Manager contains disallowed fields: managerFilePatterns
Invalid configuration option: customManagers[0].managerFilePatterns
```

`managerFilePatterns` was introduced in Renovate v40+ as the replacement for `fileMatch`. Any validator pinned to (or cached at) an older Renovate version will reject the field. Reverting the field name to `fileMatch` makes the config validate cleanly on both old and new Renovate.

Newer Renovate auto-migrates `fileMatch` → `managerFilePatterns` at runtime (verified with `renovate-config-validator` from `renovate@43.150.0` — exit code 0, only an informational migration notice). The hosted bot's behavior is unchanged.

## Test plan

- [x] `npx --package renovate -- renovate-config-validator` exits 0
- [x] Verified migration produces equivalent `managerFilePatterns: ["/^\\.github/workflows/ghalint\\.yml$/"]`
- [ ] Confirm the existing `# renovate:` comments in `.github/workflows/ghalint.yml` continue to be picked up after the next Renovate run


---
_Generated by [Claude Code](https://claude.ai/code/session_01VSDo9NNLz1LMx18irAzhEN)_