### PR TITLE
fix: use "JWT" as typ header value in GitHub App JWT

### DIFF
--- a/internal/jwt/jwt.go
+++ b/internal/jwt/jwt.go
@@ -27,7 +27,7 @@ type Signer interface {
 // now is the reference time; callers should pass time.Now().
 func Build(ctx context.Context, signer Signer, appID string, now time.Time) (string, error) {
 	header := map[string]any{
-		"typ": "token",
+		"typ": "JWT",
 		"alg": "RS256",
 	}
 

--- a/internal/jwt/jwt_test.go
+++ b/internal/jwt/jwt_test.go
@@ -52,8 +52,8 @@ func TestBuild(t *testing.T) {
 				if err := json.Unmarshal(headerBytes, &header); err != nil {
 					t.Fatalf("failed to unmarshal header: %v", err)
 				}
-				if header["typ"] != "token" {
-					t.Errorf("header[typ] = %q, want %q", header["typ"], "token")
+				if header["typ"] != "JWT" {
+					t.Errorf("header[typ] = %q, want %q", header["typ"], "JWT")
 				}
 				if header["alg"] != "RS256" {
 					t.Errorf("header[alg] = %q, want %q", header["alg"], "RS256")


### PR DESCRIPTION
## Summary

- Change JWT `typ` header value from `"token"` to `"JWT"` in `internal/jwt/jwt.go`
- Update the corresponding test expectation in `internal/jwt/jwt_test.go`

## Background / Motivation

[GitHub's documentation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app) explicitly specifies `"JWT"` as the correct value for the `typ` header field, which also aligns with RFC 7519. The previous value `"token"` happened to be accepted by GitHub, but deviated from both the spec and the official docs.