### PR TITLE
ci: assign yagihash as reviewer on sync-permissions PR

### DIFF
--- a/.github/workflows/sync-permissions.yml
+++ b/.github/workflows/sync-permissions.yml
@@ -71,7 +71,8 @@ jobs:
               --title "🤖 Sync GitHub App Permissions" \
               --body "This PR updates \`action.yml\` inputs and args based on the latest GitHub App permissions from octokit/openapi." \
               --base main \
-              --head "$BRANCH_NAME" 2>&1 || gh pr view "$BRANCH_NAME" --json url --jq '.url')
+              --head "$BRANCH_NAME" \
+              --reviewer yagihash 2>&1 || gh pr view "$BRANCH_NAME" --json url --jq '.url')
 
             {
               echo "## Sync GitHub App Permissions"


### PR DESCRIPTION
## Summary
- Add `--reviewer yagihash` to the `gh pr create` command in `sync-permissions.yml`

## Background / Motivation
The sync-permissions workflow creates automated PRs to keep `action.yml` in sync with the latest GitHub App permissions. Without an explicit reviewer, these PRs had no assigned reviewer and could be missed.