### PR TITLE
ci: introduce cicd-sensor for eBPF-based workflow monitoring

### DIFF
--- a/.cicd-sensor/config.yaml
+++ b/.cicd-sensor/config.yaml
@@ -1,0 +1,1 @@
+monitor_mode: true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,11 +17,13 @@ jobs:
       name: main
       deployment: false
     permissions:
+      actions: write
       contents: write
       packages: write
       id-token: write
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ghalint.yml
+++ b/.github/workflows/ghalint.yml
@@ -8,14 +8,16 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      actions: write
       contents: read
       pull-requests: read
     outputs:
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -30,13 +32,15 @@ jobs:
   ghalint:
     needs: changes
     if: needs.changes.outputs.workflows == 'true'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      actions: write
       contents: read
       attestations: read
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -62,13 +66,15 @@ jobs:
   actionlint:
     needs: changes
     if: needs.changes.outputs.workflows == 'true'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      actions: write
       contents: read
       attestations: read
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -10,10 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      actions: write
       contents: read
       id-token: write
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,14 @@ jobs:
       deployment: false
     timeout-minutes: 15
     permissions:
+      actions: write
       contents: write
       packages: write
       id-token: write
       attestations: write
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sync-permissions.yml
+++ b/.github/workflows/sync-permissions.yml
@@ -14,11 +14,13 @@ jobs:
       deployment: false
     timeout-minutes: 15
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       id-token: write
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -11,10 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: write
       contents: read
       id-token: write
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -11,11 +11,13 @@ jobs:
       deployment: false
     timeout-minutes: 30
     permissions:
+      actions: write
       contents: read
       packages: write
       id-token: write
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,16 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      actions: write
       contents: read
       pull-requests: read
     outputs:
       go: ${{ steps.filter.outputs.go }}
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -36,9 +38,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      actions: write
       contents: read
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/verify-release-image.yml
+++ b/.github/workflows/verify-release-image.yml
@@ -13,9 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: write
       packages: read
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - name: Checkout repository
         if: startsWith(github.head_ref, 'tagpr-')
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Add `.cicd-sensor/config.yaml` with `monitor_mode: true` to start in observation mode
- Add `cicd-sensor/cicd-sensor-action` as the first step in every workflow job
- Add `permissions: actions: write` to every job (required for artifact upload)
- Change `runs-on: ubuntu-slim` → `runs-on: ubuntu-latest` for jobs that used slim runners (`ghalint.yml`: `changes`, `ghalint`, `actionlint`; `test.yml`: `changes`) — cicd-sensor requires a full Ubuntu runner with eBPF support

## Background / Motivation

[cicd-sensor](https://github.com/cicd-sensor/cicd-sensor) uses eBPF to monitor syscalls during workflow execution, detecting unexpected outbound connections or file accesses. Starting with `monitor_mode: true` allows reviewing false positives before enabling enforcement mode.

All modified workflows were validated with pinact, ghalint, and actionlint — all checks pass clean.