### PR TITLE
fix: harden token handling, CI digest verification, and supply chain pinning

### DIFF
--- a/.github/workflows/sync-permissions.yml
+++ b/.github/workflows/sync-permissions.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Get OpenAPI schema file
         run: |
-          curl https://raw.githubusercontent.com/octokit/openapi/refs/heads/main/generated/api.github.com.json -o "$RUNNER_TEMP/api.github.com.json"
+          curl -fsSL https://raw.githubusercontent.com/octokit/openapi/refs/heads/main/generated/api.github.com.json -o "$RUNNER_TEMP/api.github.com.json"
 
       - name: Update action.yml
         run: |

--- a/.github/workflows/verify-release-image.yml
+++ b/.github/workflows/verify-release-image.yml
@@ -19,11 +19,29 @@ jobs:
     steps:
       - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
       - name: Checkout repository
-        if: startsWith(github.head_ref, 'tagpr-')
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      # The digest in action.yml is the integrity anchor of the released action.
+      # Only build-release.yml (running on tagpr-* branches) may change it; any
+      # other PR touching the image reference is rejected here.
+      - name: Verify image reference is unchanged
+        if: "!startsWith(github.head_ref, 'tagpr-')"
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          BASE_IMAGE=$(git show "origin/$BASE_REF:action.yml" | grep -oP 'docker://[^ "]+' | head -1)
+          HEAD_IMAGE=$(grep -oP 'docker://[^ "]+' action.yml | head -1)
+
+          if [ "$BASE_IMAGE" != "$HEAD_IMAGE" ]; then
+            echo "FAIL: the image reference in action.yml may only be updated by the build-release workflow (tagpr-* branches)"
+            echo "Base: $BASE_IMAGE"
+            echo "Head: $HEAD_IMAGE"
+            exit 1
+          fi
+          echo "OK: image reference unchanged ($HEAD_IMAGE)"
 
       - name: Login to GHCR
         if: startsWith(github.head_ref, 'tagpr-')

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 WORKDIR /app
 
 RUN apk add --no-cache upx
@@ -12,6 +12,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s" -trimpath -o /post ./cmd/pos
 RUN upx --best /ghat
 RUN upx --best /post
 
-FROM alpine:3.23.4
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 COPY --from=builder /ghat /ghat
 COPY --from=builder /post /post

--- a/internal/actions/actions.go
+++ b/internal/actions/actions.go
@@ -17,8 +17,9 @@ func SetOutput(key, value string) error {
 		return fmt.Errorf("GITHUB_OUTPUT environment variable is not set")
 	}
 
+	// The value may be a secret, so it must not be echoed back in the error.
 	if strings.Contains(value, "\n") {
-		return fmt.Errorf("SetOutput does not support new-line characters in the value: %s", value)
+		return fmt.Errorf("SetOutput does not support new-line characters in the value")
 	}
 
 	if err := writeKeyValue(outputFilePath, key, value); err != nil {
@@ -42,8 +43,9 @@ func SetState(key, value string) error {
 		return fmt.Errorf("value is empty")
 	}
 
+	// The value may be a secret, so it must not be echoed back in the error.
 	if strings.Contains(value, "\n") {
-		return fmt.Errorf("SetState does not support new-line characters in the value: %s", value)
+		return fmt.Errorf("SetState does not support new-line characters in the value")
 	}
 
 	if err := writeKeyValue(stateFilePath, strings.ToUpper(key), value); err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -66,7 +67,12 @@ func (c *Client) newRequest(method, path string, body any) (*http.Request, error
 }
 
 func (c *Client) GetInstallationByOwner(owner string) (*InstallationResponse, error) {
-	path := fmt.Sprintf("users/%s/installation", owner)
+	if owner == "" {
+		return nil, fmt.Errorf("owner is empty")
+	}
+	// PathEscape prevents path traversal / query injection when owner comes
+	// from untrusted callers of the public pkg/ghat API.
+	path := fmt.Sprintf("users/%s/installation", url.PathEscape(owner))
 	req, err := c.newRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -120,7 +120,7 @@ func TestGetInstallationByOwner(t *testing.T) {
 			},
 		},
 		{
-			name:  "空のowner",
+			name:  "empty owner",
 			owner: "",
 			roundTripFunc: func(req *http.Request) (*http.Response, error) {
 				return nil, errors.New("request must not be sent for empty owner")
@@ -128,7 +128,7 @@ func TestGetInstallationByOwner(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:  "パストラバーサルを含むownerはエスケープされる",
+			name:  "owner containing path traversal is escaped",
 			owner: "../app/installations",
 			roundTripFunc: func(req *http.Request) (*http.Response, error) {
 				return newResponse(http.StatusOK, `{"id": 1}`), nil
@@ -144,7 +144,7 @@ func TestGetInstallationByOwner(t *testing.T) {
 			},
 		},
 		{
-			name:  "クエリ文字を含むownerはエスケープされる",
+			name:  "owner containing query characters is escaped",
 			owner: "owner?per_page=1#x",
 			roundTripFunc: func(req *http.Request) (*http.Response, error) {
 				return newResponse(http.StatusOK, `{"id": 1}`), nil

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -119,6 +119,48 @@ func TestGetInstallationByOwner(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:  "空のowner",
+			owner: "",
+			roundTripFunc: func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("request must not be sent for empty owner")
+			},
+			wantErr: true,
+		},
+		{
+			name:  "パストラバーサルを含むownerはエスケープされる",
+			owner: "../app/installations",
+			roundTripFunc: func(req *http.Request) (*http.Response, error) {
+				return newResponse(http.StatusOK, `{"id": 1}`), nil
+			},
+			wantID:  1,
+			wantErr: false,
+			checkReq: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				wantPath := "/users/..%2Fapp%2Finstallations/installation"
+				if got := req.URL.EscapedPath(); got != wantPath {
+					t.Errorf("EscapedPath = %q, want %q", got, wantPath)
+				}
+			},
+		},
+		{
+			name:  "クエリ文字を含むownerはエスケープされる",
+			owner: "owner?per_page=1#x",
+			roundTripFunc: func(req *http.Request) (*http.Response, error) {
+				return newResponse(http.StatusOK, `{"id": 1}`), nil
+			},
+			wantID:  1,
+			wantErr: false,
+			checkReq: func(t *testing.T, req *http.Request) {
+				t.Helper()
+				if got := req.URL.RawQuery; got != "" {
+					t.Errorf("RawQuery = %q, want empty", got)
+				}
+				if got := req.URL.Fragment; got != "" {
+					t.Errorf("Fragment = %q, want empty", got)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -28,6 +29,12 @@ func Load() (*Config, error) {
 	var c Config
 	if err := envconfig.Process("INPUT", &c); err != nil {
 		return nil, err
+	}
+
+	// The JWT and the issued token are sent in the Authorization header, so
+	// plaintext transport must never be allowed.
+	if !strings.HasPrefix(c.BaseURL, "https://") {
+		return nil, fmt.Errorf("base_url must start with https://: %s", c.BaseURL)
 	}
 
 	if c.Owner == "" {

--- a/internal/input/input_test.go
+++ b/internal/input/input_test.go
@@ -76,6 +76,46 @@ func TestLoad_EmptyKeyVersion(t *testing.T) {
 	}
 }
 
+func TestLoad_NonHTTPSBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr bool
+	}{
+		{
+			name:    "https URL is accepted",
+			baseURL: "https://github.example.com/api/v3",
+			wantErr: false,
+		},
+		{
+			name:    "http URL is rejected",
+			baseURL: "http://api.github.com",
+			wantErr: true,
+		},
+		{
+			name:    "scheme-less URL is rejected",
+			baseURL: "api.github.com",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("INPUT_APP_ID", "12345")
+			t.Setenv("INPUT_BASE_URL", tt.baseURL)
+			t.Setenv("INPUT_KMS_PROJECT_ID", "project-id")
+			t.Setenv("INPUT_KMS_KEYRING_ID", "keyring-id")
+			t.Setenv("INPUT_KMS_KEY_ID", "key-id")
+			t.Setenv("INPUT_KMS_LOCATION", "us-central1")
+
+			_, err := Load()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestRepositories_Decode(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/scripts/update-permissions.sh
+++ b/scripts/update-permissions.sh
@@ -5,8 +5,13 @@ INPUT_JSON="$1"
 ACTION_YML="action.yml"
 NEW_YML="action.yml.new"
 
+# The schema is third-party content (octokit/openapi): keys must stay in a safe
+# charset and descriptions are JSON-escaped (@json) so they cannot break out of
+# the YAML double-quoted scalar.
 jq -r '.components.schemas["app-permissions"].properties | to_entries | .[] |
-  "  permission_" + .key + ":\n    description: \"" + .value.description + " (" + (.value.enum | join("/")) + ")\"\n    required: false"' \
+  "  permission_" + (.key | if test("^[a-zA-Z0-9_-]+$") then . else error("unexpected permission key: " + .) end)
+  + ":\n    description: " + ((.value.description + " (" + (.value.enum | join("/")) + ")") | @json)
+  + "\n    required: false"' \
   "$INPUT_JSON" > inputs_fragment.txt
 
 awk '


### PR DESCRIPTION
## Summary
- **verify-release-image.yml**: previously every verification step was gated on `startsWith(github.head_ref, 'tagpr-')`, so a non-tagpr PR rewriting the `action.yml` image digest would pass the `verify` required check without any inspection. Checkout now always runs, and non-tagpr PRs fail if the `image:` reference differs from the base branch — only the build-release workflow may change it.
- **internal/client**: `owner` is now path-escaped (`url.PathEscape`) and rejected when empty in `GetInstallationByOwner`, preventing path traversal / query injection through the public `pkg/ghat` API where `owner` may be untrusted input. Added table-driven tests for both vectors.
- **internal/input**: `base_url` must start with `https://`; the JWT and issued token travel in the `Authorization` header and must never be sent over plaintext. Added tests.
- **internal/actions**: `SetOutput` / `SetState` newline-validation errors no longer echo the value, which is typically the installation token.
- **scripts/update-permissions.sh**: descriptions from the octokit/openapi schema (third-party content) are now JSON-escaped via jq `@json`, and permission keys are validated against `^[a-zA-Z0-9_-]+$` (the script aborts otherwise), preventing YAML injection into `action.yml`. The sync workflow's `curl` now uses `-fsSL` so HTTP errors fail fast.
- **Dockerfile**: base images pinned by digest (verified against both the Docker Hub API and the registry `docker-content-digest`); tags are kept so Renovate continues to update them.

## Background / Motivation
These changes address the Medium/Low findings from a security review of the repository. The action's distribution integrity hinges on the image digest in `action.yml`, so the verification gap for non-tagpr PRs was the highest-priority fix. The remaining items reduce injection surface in the Go code and the permission-sync pipeline, and tighten supply chain pinning.

Verification:
- `go test -cover -race ./...` passes for all packages
- `pinact run --min-age 7`, `ghalint run`, `ghalint act`, and `actionlint` are clean
- `update-permissions.sh` reproduces a byte-identical `action.yml` with the current upstream schema; crafted malicious descriptions stay escaped and malicious keys abort the script
- The new image-reference check was simulated locally against `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)