### PR TITLE
chore: configure prCreation and internalChecksFilter for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,8 @@
   "platformAutomerge": true,
   "rangeStrategy": "pin",
   "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
   "osvVulnerabilityAlerts": true,
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Add `"internalChecksFilter": "strict"` so versions that do not satisfy `minimumReleaseAge: 3 days` are filtered out of update candidates
- Add `"prCreation": "not-pending"` so PR creation is deferred until internal checks pass when only pending versions are available

## Background / Motivation
With `minimumReleaseAge: 3 days` alone, Renovate still creates PRs for freshly released versions immediately; the pending status check just blocks automerge while CI runs needlessly. These two settings make Renovate prefer versions that already satisfy the release age, and hold off PR creation otherwise, so PRs only appear once they are actually eligible for automerge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)