### PR TITLE
ci: drop actions: write from all workflow jobs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,7 +17,6 @@ jobs:
       name: main
       deployment: false
     permissions:
-      actions: write
       contents: write
       packages: write
       id-token: write

--- a/.github/workflows/ghalint.yml
+++ b/.github/workflows/ghalint.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      actions: write
       contents: read
       pull-requests: read
     outputs:
@@ -35,7 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      actions: write
       contents: read
       attestations: read
 
@@ -69,7 +67,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      actions: write
       contents: read
       attestations: read
 

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      actions: write
       contents: read
       id-token: write
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
       deployment: false
     timeout-minutes: 15
     permissions:
-      actions: write
       contents: write
       packages: write
       id-token: write

--- a/.github/workflows/sync-permissions.yml
+++ b/.github/workflows/sync-permissions.yml
@@ -14,7 +14,6 @@ jobs:
       deployment: false
     timeout-minutes: 15
     permissions:
-      actions: write
       contents: write
       pull-requests: write
       id-token: write

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: write
       contents: read
       id-token: write
 

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -11,7 +11,6 @@ jobs:
       deployment: false
     timeout-minutes: 30
     permissions:
-      actions: write
       contents: read
       packages: write
       id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      actions: write
       contents: read
       pull-requests: read
     outputs:
@@ -38,7 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      actions: write
       contents: read
 
     steps:

--- a/.github/workflows/verify-release-image.yml
+++ b/.github/workflows/verify-release-image.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      actions: write
       packages: read
 
     steps:


### PR DESCRIPTION
## Summary
- Remove `actions: write` from all 9 workflow files (12 occurrences total)

## Background / Motivation
All workflows had `actions: write` set on `GITHUB_TOKEN`, but investigation showed no step actually needed it.

The sole candidate was `cicd-sensor/cicd-sensor-action`, which uploads artifacts (`cicd-sensor-report`, `cicd-sensor-attestation`) in its post step. However, it uses `@actions/artifact v6.2.1`, which performs uploads via `ACTIONS_RUNTIME_TOKEN` (automatically injected by the runner) rather than `GITHUB_TOKEN`. The only thing cicd-sensor does with `GITHUB_TOKEN` is fetch `.cicd-sensor/config.yaml` from the repo, which requires only `contents: read`.

No other step in any workflow calls GitHub Actions APIs that require `actions: write`.