### PR TITLE
fix: switch permissions source to github/rest-api-description

### DIFF
--- a/.github/workflows/sync-permissions.yml
+++ b/.github/workflows/sync-permissions.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Get OpenAPI schema file
         run: |
-          curl -fsSL https://raw.githubusercontent.com/octokit/openapi/refs/heads/main/generated/api.github.com.json -o "$RUNNER_TEMP/api.github.com.json"
+          curl -fsSL https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json -o "$RUNNER_TEMP/api.github.com.json"
 
       - name: Update action.yml
         run: |

--- a/scripts/update-permissions.sh
+++ b/scripts/update-permissions.sh
@@ -5,7 +5,7 @@ INPUT_JSON="$1"
 ACTION_YML="action.yml"
 NEW_YML="action.yml.new"
 
-# The schema is third-party content (octokit/openapi): keys must stay in a safe
+# The schema is third-party content (github/rest-api-description): keys must stay in a safe
 # charset and descriptions are JSON-escaped (@json) so they cannot break out of
 # the YAML double-quoted scalar.
 jq -r '.components.schemas["app-permissions"].properties | to_entries | .[] |


### PR DESCRIPTION
## Summary

- Switch the OpenAPI spec source in `sync-permissions.yml` from `octokit/openapi` to `github/rest-api-description`
- Update source reference comment in `scripts/update-permissions.sh`

## Background / Motivation

The sync workflow was using `octokit/openapi` as the permissions source, but that repo lags behind the authoritative `github/rest-api-description`. Comparing the two revealed:

- `github/rest-api-description` has `code_quality` and `organization_copilot_agent_settings` that `octokit/openapi` is missing — these were never synced into `action.yml`
- `octokit/openapi` retains `team_discussions`, which has already been removed from the official spec

Switching to `github/rest-api-description` ensures future syncs stay in step with what GitHub actually exposes. The `action.yml` update itself will be applied by re-running the fixed workflow.