### PR TITLE
fix: use jq --input for git trees API call to avoid HTTP 422

### DIFF
--- a/.github/workflows/sync-permissions.yml
+++ b/.github/workflows/sync-permissions.yml
@@ -73,13 +73,11 @@ jobs:
               --field content="$(base64 -w0 action.yml)" \
               --jq '.sha')
 
-            TREE_SHA=$(gh api "repos/${REPO}/git/trees" \
-              --field base_tree="${BASE_TREE}" \
-              --field "tree[][path]=action.yml" \
-              --field "tree[][mode]=100644" \
-              --field "tree[][type]=blob" \
-              --field "tree[][sha]=${BLOB_SHA}" \
-              --jq '.sha')
+            TREE_SHA=$(jq -n \
+              --arg base_tree "${BASE_TREE}" \
+              --arg sha "${BLOB_SHA}" \
+              '{base_tree: $base_tree, tree: [{path: "action.yml", mode: "100644", type: "blob", sha: $sha}]}' | \
+              gh api "repos/${REPO}/git/trees" --input - --jq '.sha')
 
             COMMIT_SHA=$(jq -n \
               --arg msg "chore: sync GitHub App permissions" \


### PR DESCRIPTION
## Summary

- Replace `--field "tree[][]"` with `jq -n ... | gh api --input -` for the git trees API call in `sync-permissions.yml`

## Background / Motivation

The previous approach used `--field "tree[][path]=..."`, `--field "tree[][mode]=..."`, etc. to build the tree payload. However, `gh api --field` does not group multiple `tree[][]` entries into a single object — each `--field` creates a separate array entry, resulting in a malformed request that the API rejects with HTTP 422 (`Must supply a valid tree.mode`).

Building the JSON with `jq -n` and passing it via `--input -` ensures the tree entry is one correctly structured object with all required fields.