### PR TITLE
ci(ghalint): run ghalint run and act in parallel

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,11 @@ paths:
   .github/workflows/**/*.yml:
     ignore:
       - 'file "/(ghat|post)" does not exist'
+  # Parallel steps (background / wait-all) are a new GitHub Actions feature that
+  # actionlint v1.7.12 does not yet recognize. Remove this entry once actionlint
+  # ships support for them.
+  # https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
+  .github/workflows/ghalint.yml:
+    ignore:
+      - 'unexpected key "background" for step'
+      - 'step must run script with "run" section or run action with "uses" section'

--- a/.github/workflows/ghalint.yml
+++ b/.github/workflows/ghalint.yml
@@ -55,11 +55,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      # Run the two independent ghalint checks concurrently using the new
+      # parallel steps feature (background steps + wait-all).
+      # https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/
       - name: Run ghalint run
         run: ./ghalint run
+        background: true
 
       - name: Run ghalint act
         run: ./ghalint act
+        background: true
+
+      - wait-all:
 
   actionlint:
     needs: changes


### PR DESCRIPTION
## Summary

Tries out the newly released [GitHub Actions parallel steps feature](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) in `ghalint.yml`.

The `ghalint` job runs two independent, read-only checks against the same checkout — `./ghalint run` and `./ghalint act`. They had no ordering dependency, so they are now run concurrently using `background: true` on each, followed by a `wait-all:` step (the primitives the new `parallel` keyword desugars to).

```yaml
- name: Run ghalint run
  run: ./ghalint run
  background: true

- name: Run ghalint act
  run: ./ghalint act
  background: true

- wait-all:
```

## actionlint compatibility

The `actionlint` job in this same workflow lints `ghalint.yml` itself, and the pinned **actionlint v1.7.12 predates this feature**, so it rejects the new `background` / `wait-all` keys with `[syntax-check]` errors:

```
unexpected key "background" for step to run shell command ...
step must run script with "run" section or run action with "uses" section
```

To keep the required `actionlint` check green, a scoped, clearly-temporary entry was added to `.github/actionlint.yaml` that ignores exactly these two messages **for `ghalint.yml` only**. It should be removed once an actionlint release recognizes parallel steps natively (a TODO comment in the config notes this).

`ghalint` v1.5.6 itself accepts the new keys (verified locally, exit 0), so no change was needed there.

## Verification

Locally with the pinned tool versions:

- `actionlint` (with the new config auto-loaded): exit 0
- `ghalint run`: exit 0
- `ghalint act`: exit 0

## Notes / caveats

- `background` / `wait-all` are used directly rather than the higher-level `parallel:` group keyword, because the primitive form has a confirmed, documented syntax and maps 1:1 onto this use case.
- The actionlint suppression is intentionally narrow (two exact messages, single file) and temporary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Urg6jVTtr7KfrtW1FGWyxk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Urg6jVTtr7KfrtW1FGWyxk)_