### PR TITLE
chore: upgrade to Go 1.27

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26'
+          go-version: '1.27'
 
       - name: Build release binaries
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26'
+          go-version: '1.27'
 
       - name: go test
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 It also exposes a public Go library (`pkg/ghat`) that external Go modules can import to perform the same operations programmatically.
 
 **Module path:** `github.com/yagihash/ghat/v2`
-**Language:** Go 1.26+
+**Language:** Go 1.27+
 **License:** MIT
 
 ---
@@ -51,7 +51,7 @@ ghat/
 ├── .github/
 │   └── workflows/             # CI/CD pipelines (test, edge build, release, linting)
 ├── action.yml                 # GitHub Action metadata (inputs, outputs, Docker entrypoint)
-├── Dockerfile                 # Multi-stage build: golang:1.26-alpine → alpine:3.23.3
+├── Dockerfile                 # Multi-stage build: golang:1.27-alpine → alpine:3.23.3
 ├── mise.toml                  # Tool versions (Go) and task runner (build, test, coverage)
 ├── go.mod / go.sum
 ├── renovate.json
@@ -64,7 +64,7 @@ ghat/
 
 ### Prerequisites
 
-- [mise](https://mise.jdx.dev/) (`mise install` to activate Go 1.26.1)
+- [mise](https://mise.jdx.dev/) (`mise install` to activate Go 1.27.0)
 - Docker (for building the container image)
 
 ### Common Tasks
@@ -88,7 +88,7 @@ docker build -t ghat .
 ```
 
 The Dockerfile uses a two-stage build:
-1. `golang:1.26-alpine` — compiles both binaries with `CGO_ENABLED=0` and compresses with `upx`
+1. `golang:1.27-alpine` — compiles both binaries with `CGO_ENABLED=0` and compresses with `upx`
 2. `alpine:3.23.3` — minimal runtime image
 
 ---

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.27.0-alpine@sha256:4c9fe60190a2a3350ddc51de80d0224b8a6698d12bdfc999fee45ea9d6c46dbc AS builder
 WORKDIR /app
 
 RUN apk add --no-cache upx

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yagihash/ghat/v2
 
-go 1.26.1
+go 1.27.0
 
 require (
 	cloud.google.com/go/kms v1.31.0

--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -15,9 +15,9 @@ type Config struct {
 	Permissions  map[string]string `envconfig:"PERMISSION"`
 	BaseURL      string            `envconfig:"BASE_URL" default:"https://api.github.com"`
 
-	ProjectID  string `envconfig:"KMS_PROJECT_ID" required:"true"`
-	KeyRingID  string `envconfig:"KMS_KEYRING_ID" required:"true"`
-	KeyID      string `envconfig:"KMS_KEY_ID" required:"true"`
+	ProjectID string `envconfig:"KMS_PROJECT_ID" required:"true"`
+	KeyRingID string `envconfig:"KMS_KEYRING_ID" required:"true"`
+	KeyID     string `envconfig:"KMS_KEY_ID" required:"true"`
 	// KeyVersion defaults to "" to signal automatic detection of the latest enabled
 	// KMS key version. GitHub Actions passes an explicit empty string for optional
 	// inputs the user leaves unset, so the zero value carries the same semantic.
@@ -61,8 +61,8 @@ func (r *Repositories) Decode(value string) error {
 
 	res := make(Repositories, 0)
 	normalized := strings.ReplaceAll(value, "\n", ",")
-	repos := strings.Split(normalized, ",")
-	for _, repo := range repos {
+	repos := strings.SplitSeq(normalized, ",")
+	for repo := range repos {
 		trimmed := strings.TrimSpace(repo)
 		if trimmed != "" {
 			res = append(res, trimmed)

--- a/internal/kms/kms.go
+++ b/internal/kms/kms.go
@@ -57,8 +57,8 @@ func (w *kmsClientWrapper) LatestEnabledKeyVersion(ctx context.Context, parent s
 		if err != nil {
 			return "", fmt.Errorf("failed to list crypto key versions: %w", err)
 		}
-		parts := strings.Split(v.Name, "/")
-		n, err := strconv.ParseInt(parts[len(parts)-1], 10, 64)
+		_, last, _ := strings.CutLast(v.Name, "/")
+		n, err := strconv.ParseInt(last, 10, 64)
 		if err != nil {
 			continue
 		}

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.3"
+go = "1.27.0"
 
 [tasks.build]
 description = "Build both binaries to dist/"


### PR DESCRIPTION
## Summary
- Bump the Go toolchain to 1.27.0 across `go.mod`, `mise.toml`, the `Dockerfile` base image (`golang:1.27.0-alpine`, digest updated), `.github/workflows/test.yml`, and `.github/workflows/release.yml`
- Update `CLAUDE.md`'s Go version references to match
- Adopt `strings.CutLast` (new in Go 1.27) in `internal/kms/kms.go` to simplify extracting the trailing key-version segment from a KMS resource name
- Apply the `strings.SplitSeq` rewrite `go fix` suggested for the repository-list decoder in `internal/input/input.go`, avoiding an intermediate slice allocation

## Background / Motivation
Go 1.27 was released. I audited the codebase against the release notes and found most of the new surface area (crypto/tls, crypto/x509, macOS platform minimums, generic methods, the new `uuid` package) doesn't apply here — ghat doesn't touch TLS/x509 directly, doesn't target macOS, and has no generic types. The two `strings` package additions above were the concrete, low-risk wins worth adopting. `go build`, `go vet`, and `go test -v -cover -race ./...` all pass on 1.27.

Note: `docker build` could not be verified locally (no Docker daemon available in this environment) — worth a sanity check in CI before merge.